### PR TITLE
Add ASM library dependency for Java bytecode generation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,19 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
     <dependencies>
+        <!-- ASM for Java bytecode generation -->
+        <dependency>
+            <groupId>org.ow2.asm</groupId>
+            <artifactId>asm</artifactId>
+            <version>9.6</version>
+        </dependency>
+        <dependency>
+            <groupId>org.ow2.asm</groupId>
+            <artifactId>asm-util</artifactId>
+            <version>9.6</version>
+        </dependency>
+
+        <!-- Testing -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>


### PR DESCRIPTION
Added org.ow2.asm:asm (v9.6) and asm-util for implementing the bytecode generation phase of the compiler. This will enable compilation of Siyo programs to JVM .class files instead of interpretation-only.